### PR TITLE
Ensure mr indication table has four labels

### DIFF
--- a/Table1.py
+++ b/Table1.py
@@ -314,15 +314,9 @@ mri_rename_map = {
 df["MR_indication_group"] = df["MR_indication_simplified"].map(mri_rename_map).astype("object")
 df["MR_indication_group"] = df["MR_indication_group"].fillna("Missing")
 
-# Build a TableOne summarizing key variables by MRI indication
-mri_columns = demo + disease + device_info + position + label
-mri_categorical = (
-    discrete_demo
-    + discrete_disease
-    + discrete_device_info
-    + discrete_position
-    + discrete_label
-)
+# Build a TableOne summarizing four label outcomes by MRI indication
+mri_columns = label_group_cols
+mri_categorical = label_group_cols
 
 create_table1(
     "MRI_indication",


### PR DESCRIPTION
Align MRI indication table columns to use only four label columns to match other tables.

---
<a href="https://cursor.com/background-agent?bcId=bc-49cf6b3a-18bd-4a6f-acce-8a8284d8d0f7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-49cf6b3a-18bd-4a6f-acce-8a8284d8d0f7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

